### PR TITLE
Work on virtual generation

### DIFF
--- a/autoglue/ClassEntity.cc
+++ b/autoglue/ClassEntity.cc
@@ -206,7 +206,7 @@ void ClassEntity::generateInterceptionFunctions(BindingGenerator& generator)
 				auto overridden = group.getOverload(i).getOverridden();
 				assert(overridden);
 
-				if(overridden->getUsages() > 0 && !overridden->isOverride())
+				if(overridden->getUsages() > 0 && overridden->isOverridable())
 				{
 					generator.generateInterceptionFunction(group.getOverload(i), *this);
 				}

--- a/autoglue/ClassEntity.cc
+++ b/autoglue/ClassEntity.cc
@@ -187,6 +187,11 @@ std::shared_ptr <ClassEntity> ClassEntity::getConcreteType()
 	return concreteType;
 }
 
+bool ClassEntity::isConcreteType()
+{
+	return isConcrete;
+}
+
 void ClassEntity::generateInterceptionFunctions(BindingGenerator& generator)
 {
 	if(concreteType)
@@ -201,7 +206,7 @@ void ClassEntity::generateInterceptionFunctions(BindingGenerator& generator)
 				auto overridden = group.getOverload(i).getOverridden();
 				assert(overridden);
 
-				if(overridden->getUsages() > 0)
+				if(overridden->getUsages() > 0 && !overridden->isOverride())
 				{
 					generator.generateInterceptionFunction(group.getOverload(i), *this);
 				}
@@ -216,6 +221,12 @@ void ClassEntity::generateInterceptionContext(BindingGenerator& generator)
 	{
 		generator.generateInterceptionContext(*this);
 	}
+}
+
+bool ClassEntity::matchType(Entity& entity)
+{
+	return entity.getType() == Entity::Type::Type &&
+			static_cast <TypeEntity&> (entity).getType() == Type::Class;
 }
 
 const char* ClassEntity::getTypeString()

--- a/autoglue/Entity.cc
+++ b/autoglue/Entity.cc
@@ -112,6 +112,12 @@ void Entity::resetGenerated()
 {
 	generated = false;
 
+	if(!initialized)
+	{
+		onInitialize();
+		initialized = true;
+	}
+
 	for(auto child : children)
 	{
 		child->resetGenerated();
@@ -189,8 +195,17 @@ bool Entity::hasName(std::string_view str)
 	return name == str;
 }
 
+void Entity::onInitialize()
+{
+}
+
 void Entity::onFirstUse()
 {
+}
+
+void Entity::resetUsages()
+{
+	usages = 0;
 }
 
 void Entity::adoptEntity(Entity& entity)

--- a/autoglue/FunctionEntity.cc
+++ b/autoglue/FunctionEntity.cc
@@ -251,7 +251,9 @@ std::shared_ptr <FunctionEntity> FunctionEntity::createOverride()
 		functionOverride->overridable = false;
 		functionOverride->interface = false;
 		functionOverride->overrides = true;
+		functionOverride->overrideCreatedFor = shared_from_this();
 
+		functionOverride->resetUsages();
 		return functionOverride;
 	}
 
@@ -282,6 +284,11 @@ bool FunctionEntity::shouldPrepareClass()
 	}
 
 	return false;
+}
+
+std::shared_ptr <FunctionEntity> FunctionEntity::getOverridden()
+{
+	return overrideCreatedFor.expired() ? nullptr : overrideCreatedFor.lock();
 }
 
 const char* FunctionEntity::getTypeString()

--- a/autoglue/FunctionEntity.cc
+++ b/autoglue/FunctionEntity.cc
@@ -241,9 +241,9 @@ void FunctionEntity::setOverloadIndex(size_t index)
 	overloadIndex = index;
 }
 
-std::shared_ptr <FunctionEntity> FunctionEntity::createInterfaceOverride()
+std::shared_ptr <FunctionEntity> FunctionEntity::createOverride()
 {
-	if(interface)
+	if(isOverridable())
 	{
 		auto ret = returnType;
 		auto functionOverride = std::make_shared <FunctionEntity> (*this);

--- a/autoglue/FunctionEntity.cc
+++ b/autoglue/FunctionEntity.cc
@@ -243,7 +243,7 @@ void FunctionEntity::setOverloadIndex(size_t index)
 
 std::shared_ptr <FunctionEntity> FunctionEntity::createOverride()
 {
-	if(isOverridable())
+	if(isOverridable() || isOverride())
 	{
 		auto ret = returnType;
 		auto functionOverride = std::make_shared <FunctionEntity> (*this);

--- a/autoglue/include/autoglue/ClassEntity.hh
+++ b/autoglue/include/autoglue/ClassEntity.hh
@@ -79,6 +79,12 @@ public:
 	/// \return The concrete type of this class or nullptr.
 	std::shared_ptr <ClassEntity> getConcreteType();
 
+	/// Checks whether this class entity is a concrete type for
+	/// another class entity.
+	///
+	/// \return True if this is a concrete type.
+	bool isConcreteType();
+
 	/// Generates the interception functions of this class.
 	///
 	/// \param generator The BindingGenerator to call functions from.
@@ -88,6 +94,12 @@ public:
 	///
 	/// \param generator The BindingGenerator to call functions from.
 	void generateInterceptionContext(BindingGenerator& generator);
+
+	/// Checks whether the given entity is a ClassEntity.
+	///
+	/// \param entity The entity to check.
+	/// \return True if the given entity is a ClassEntity.
+	static bool matchType(Entity& entity);
 
 	const char* getTypeString() override;
 

--- a/autoglue/include/autoglue/ClassEntity.hh
+++ b/autoglue/include/autoglue/ClassEntity.hh
@@ -69,9 +69,6 @@ public:
 	/// \return True if this class is abstract.
 	bool isAbstract();
 
-	/// Sets this class as abstract.
-	void setAbstract();
-
 	/// Generates a concrete type for this class if it's present.
 	///
 	/// \param generator The BindingGenerator to call functions from.
@@ -105,6 +102,7 @@ private:
 	void addInterfaceOverridesToConcrete(std::shared_ptr <ClassEntity> concrete);
 
 	bool abstract = false;
+
 	std::vector <std::weak_ptr <TypeEntity>> baseTypes;
 	std::vector <std::weak_ptr <ClassEntity>> derivedClasses;
 

--- a/autoglue/include/autoglue/ClassEntity.hh
+++ b/autoglue/include/autoglue/ClassEntity.hh
@@ -99,9 +99,10 @@ private:
 	void onFirstUse() override;
 
 	/// Adds interface overrides of this class to the given concrete type.
-	void addInterfaceOverridesToConcrete(std::shared_ptr <ClassEntity> concrete);
+	void addOverridesToConcrete(std::shared_ptr <ClassEntity> concrete);
 
 	bool abstract = false;
+	bool isConcrete = false;
 
 	std::vector <std::weak_ptr <TypeEntity>> baseTypes;
 	std::vector <std::weak_ptr <ClassEntity>> derivedClasses;

--- a/autoglue/include/autoglue/ClassEntity.hh
+++ b/autoglue/include/autoglue/ClassEntity.hh
@@ -98,6 +98,9 @@ private:
 	/// Makes sure that the base classes and constructors are used.
 	void onFirstUse() override;
 
+	/// Checks class abstractness and initializes the concrete type if necessary.
+	void onInitialize() override;
+
 	/// Adds interface overrides of this class to the given concrete type.
 	void addOverridesToConcrete(std::shared_ptr <ClassEntity> concrete);
 

--- a/autoglue/include/autoglue/Entity.hh
+++ b/autoglue/include/autoglue/Entity.hh
@@ -115,6 +115,10 @@ protected:
 
 	virtual bool hasName(std::string_view str);
 
+	/// This function is called upon the first time that the generation
+	/// state for this entity is reset.
+	virtual void onInitialize();
+
 	/// This function is implemented by the given entity class.
 	/// It calls the appropriate functions from a binding generator.
 	///
@@ -124,6 +128,10 @@ protected:
 	/// This function is called when an entity is used for the first time.
 	virtual void onFirstUse();
 
+	/// Resets the usages of this entity.
+	void resetUsages();
+
+	/// Sets this entity as the parent of the given entity.
 	void adoptEntity(Entity& entity);
 
 	const std::string name;
@@ -132,6 +140,7 @@ protected:
 private:
 	unsigned usages = 0;
 	bool preventUsage = false;
+	bool initialized = false;
 
 	bool generated = false;
 	Entity* parent = nullptr;

--- a/autoglue/include/autoglue/FunctionEntity.hh
+++ b/autoglue/include/autoglue/FunctionEntity.hh
@@ -184,11 +184,10 @@ public:
 	/// \param index The index of this overload.
 	void setOverloadIndex(size_t index);
 
-	/// Creates a new function entity representing an override of this
-	/// function if it is an interface.
+	/// Creates a new function entity representing an override of this overridable function.
 	///
-	/// \return A new function representing an override of this interface or nullptr.
-	std::shared_ptr <FunctionEntity> createInterfaceOverride();
+	/// \return A new function representing an override of this overridable or nullptr.
+	std::shared_ptr <FunctionEntity> createOverride();
 
 	/// Makes this function overload protected.
 	void setProtected();

--- a/autoglue/include/autoglue/FunctionEntity.hh
+++ b/autoglue/include/autoglue/FunctionEntity.hh
@@ -9,7 +9,8 @@ namespace ag
 class TypeReferenceEntity;
 class FunctionGroupEntity;
 
-class FunctionEntity : public Entity
+class FunctionEntity : public Entity,
+						public std::enable_shared_from_this <FunctionEntity>
 {
 public:
 	enum class Type
@@ -203,6 +204,12 @@ public:
 	/// \return True if this function is a constructor that should do further initialization.
 	bool shouldPrepareClass();
 
+	/// Gets the function overload that this overload overrides. This only is valid
+	/// when the override was created with createOverride().
+	///
+	/// \return The functio overlaod that this overrides or nullptr.
+	std::shared_ptr <FunctionEntity> getOverridden();
+
 	const char* getTypeString() override;
 
 private:
@@ -220,6 +227,8 @@ private:
 	bool compoundOperator = false;
 
 	std::shared_ptr <TypeReferenceEntity> returnType;
+	std::weak_ptr <FunctionEntity> overrideCreatedFor;
+
 	size_t overloadIndex = 0;
 	bool protectedFunction = false;
 };

--- a/autoglue/include/autoglue/FunctionEntity.hh
+++ b/autoglue/include/autoglue/FunctionEntity.hh
@@ -9,8 +9,7 @@ namespace ag
 class TypeReferenceEntity;
 class FunctionGroupEntity;
 
-class FunctionEntity : public Entity,
-						public std::enable_shared_from_this <FunctionEntity>
+class FunctionEntity : public Entity, public std::enable_shared_from_this <FunctionEntity>
 {
 public:
 	enum class Type

--- a/autoglue/include/autoglue/FunctionGroupEntity.hh
+++ b/autoglue/include/autoglue/FunctionGroupEntity.hh
@@ -15,7 +15,8 @@ public:
 	/// Adds a new overload to this function group.
 	///
 	/// \param overload The overload to add.
-	void addOverload(std::shared_ptr <FunctionEntity>&& overload);
+	/// \return True if the overload was added succesfully.
+	bool addOverload(std::shared_ptr <FunctionEntity>&& overload);
 
 	const char* getTypeString() override;
 
@@ -41,17 +42,7 @@ public:
 	/// \return The type of the contained functions.
 	FunctionEntity::Type getType();
 
-	/// Creates a new function group containing overrides for interface
-	/// functions found in this function group. This makes the interface
-	/// functions implicitly used.
-	///
-	/// \return A new function group containing the overrides or null if there are no interfaces.
-	std::shared_ptr <FunctionGroupEntity> createInterfaceOverrides();
-
-	/// Appends the overloads of the given function group to this group.
-	///
-	/// \param group The group to get overloads from.
-	void appendOverloads(std::shared_ptr <FunctionGroupEntity> group);
+	bool hasOverridable();
 
 private:
 	/// Checks if this function group has the given name or
@@ -66,6 +57,7 @@ private:
 
 	FunctionEntity::Type type;
 	size_t interfaces = 0;
+	size_t overridables = 0;
 };
 
 }

--- a/clang/Backend.cc
+++ b/clang/Backend.cc
@@ -562,6 +562,7 @@ private:
 		}
 
 		bool isProtected = false;
+		bool isOverride = false;
 		std::weak_ptr <ag::FunctionGroupEntity> privateOverrides;
 
 		// Only export public and protected member functions.
@@ -570,31 +571,25 @@ private:
 			if(decl->getAccess() != clang::AccessSpecifier::AS_public &&
 				decl->getAccess() != clang::AccessSpecifier::AS_protected)
 			{
-				bool overridesPure = false;
-
-				// If this private method doesn't override a pure method, don't export it.
+				// If this function overrides another, it should be saved.
 				for(auto overridden : cxxDecl->overridden_methods())
 				{
-					if(overridden->isPure())
+					// If the overridden method is protected, treat this private override as protected.
+					isProtected = overridden->getAccess() == clang::AccessSpecifier::AS_protected;
+					isOverride = true;
+
+					// If a function group can be created for the overriden method, save the
+					// group entity for OverloadContext to store later.
+					auto group = ensureEntityExists(overridden);
+					if(group && group->getType() == ag::Entity::Type::FunctionGroup)
 					{
-						// If the overridden method is protected, treat this private override as
-						// protected. TODO: This should probably be done in the abstraction.
-						isProtected = overridden->getAccess() == clang::AccessSpecifier::AS_protected;
-						overridesPure = true;
-
-						// If a function group can be created for the overriden method, save the
-						// group entity for OverloadContext to store later.
-						auto group = ensureEntityExists(overridden);
-						if(group && group->getType() == ag::Entity::Type::FunctionGroup)
-						{
-							privateOverrides = std::static_pointer_cast <ag::FunctionGroupEntity> (group);
-						}
-
-						break;
+						privateOverrides = std::static_pointer_cast <ag::FunctionGroupEntity> (group);
 					}
+
+					break;
 				}
 
-				if(!overridesPure)
+				if(!isOverride)
 				{
 					return;
 				}
@@ -641,9 +636,6 @@ private:
 		returnEntity->initializeContext(std::make_shared <ag::clang::TyperefContext> (
 			decl->getReturnType(), decl->getASTContext()
 		));
-
-		// If this is a method in a C++ class, check if it overrides a base class method.
-		bool isOverride = false;
 
 		if(auto* cxxDecl = clang::dyn_cast <clang::CXXMethodDecl> (decl))
 		{

--- a/clang/Backend.cc
+++ b/clang/Backend.cc
@@ -598,8 +598,6 @@ private:
 				{
 					return;
 				}
-
-				printf("Private interface implementation '%s'\n", decl->getQualifiedNameAsString().c_str());
 			}
 		}
 

--- a/clang/Backend.cc
+++ b/clang/Backend.cc
@@ -475,13 +475,6 @@ private:
 					{
 						auto classEntity = std::static_pointer_cast <ag::ClassEntity> (result);
 
-						// Since a C++ class can be abstract without defining pure virtual
-						// functions of its own, perform an extra check for it.
-						if(cxxDef->isAbstract())
-						{
-							classEntity->setAbstract();
-						}
-
 						// Since the class definition is available here, collect its base classes.
 						for(auto base : cxxDef->bases())
 						{
@@ -605,6 +598,8 @@ private:
 				{
 					return;
 				}
+
+				printf("Private interface implementation '%s'\n", decl->getQualifiedNameAsString().c_str());
 			}
 		}
 
@@ -720,12 +715,6 @@ private:
 			//std::cerr << "Unable to add function " << decl->getQualifiedNameAsString() <<
 			//			": Failed to ensure that the function group exists\n";
 			return;
-		}
-
-		// If this function is a pure virtual member function, the class should become abstract.
-		if(entity->isInterface())
-		{
-			static_cast <ag::ClassEntity&> (group->getParent()).setAbstract();
 		}
 
 		std::static_pointer_cast <ag::FunctionGroupEntity> (group)->addOverload(std::move(entity));

--- a/clang/GlueGenerator.cc
+++ b/clang/GlueGenerator.cc
@@ -141,33 +141,41 @@ public:
 
 	void generateClass(ClassEntity& entity) override
 	{
-		file << "struct " << "AG_" << entity.getName();
-
-		auto ctx = getClangContext(entity);
-		if(ctx)
+		if(!entity.isConcreteType())
 		{
-			file << " : public " << ctx->getTypeContext()->getRealName();
+			file << "struct " << "AG_" << entity.getName();
+
+			auto ctx = getClangContext(entity);
+			if(ctx)
+			{
+				file << " : public " << ctx->getTypeContext()->getRealName();
+			}
+
+			file << "\n{\n";
+
+			auto constructors = entity.resolve("Constructor");
+			if(constructors)
+			{
+				inOverride = true;
+				constructors->generate(*this);
+				constructors->resetGenerated();
+				inOverride = false;
+			}
+
+			entity.generateInterceptionContext(*this);
+			entity.generateInterceptionFunctions(*this);
+
+			entity.generateConcreteType(*this);
 		}
-
-		file << "\n{\n";
-
-		auto constructors = entity.resolve("Constructor");
-		if(constructors)
-		{
-			inOverride = true;
-			constructors->generate(*this);
-			constructors->resetGenerated();
-			inOverride = false;
-		}
-
-		entity.generateInterceptionContext(*this);
-		entity.generateInterceptionFunctions(*this);
 
 		inBridge = true;
 		entity.generateNested(*this);
 		inBridge = false;
 
-		file << "};\n\n";
+		if(!entity.isConcreteType())
+		{
+			file << "};\n\n";
+		}
 	}
 
 	void generateFunction(FunctionEntity& entity) override
@@ -198,22 +206,44 @@ public:
 
 		else if(inBridge)
 		{
-			auto ctx = getClangContext(entity);
-			assert(ctx);
-
-			// Don't generate in-class bridges for private interface overrides
-			// as they simply call a virtual bridge function and don't need data access.
-			if(ctx->getOverloadContext()->isPrivateOverride())
+			auto overridden = entity.getOverridden();
+			if(overridden)
 			{
-				return;
+				// This function should be an override residing in a concrete type.
+				// The actual containing class is the parent of the concrete type.
+				auto& containing = entity.getParent().getParent();
+
+				assert(ClassEntity::matchType(overridden->getParent()));
+				assert(ClassEntity::matchType(containing));
+
+				// Only generate functions for a virtual call in the class that originally defined
+				// the given overridable function.
+				if(static_cast <ClassEntity&> (containing).shared_from_this() !=
+					static_cast <ClassEntity&> (overridden->getParent()).shared_from_this())
+				{
+					return;
+				}
+			}
+
+			else
+			{
+				auto ctx = getClangContext(entity);
+				assert(ctx);
+
+				// Don't generate in-class bridges for private interface overrides
+				// as they simply call a virtual bridge function and don't need data access.
+				if(ctx->getOverloadContext()->isPrivateOverride())
+				{
+					return;
+				}
 			}
 
 			file << "static ";
 			entity.generateReturnType(*this, true);
 
-			if(entity.isInterface())
+			if(overridden)
 			{
-				file << "virtual_";
+				file << "AG_virtual_";
 			}
 
 			file << entity.getBridgeName(true) << '(';
@@ -253,14 +283,18 @@ public:
 		{
 			case FunctionEntity::Type::MemberFunction:
 			{
-				file << "static_cast <AG_" << entity.getParent().getHierarchy("::AG_") << "*> (" <<
-						getObjectHandleName() << ")->";
+				auto overridden = entity.getOverridden();
 
-				// If the function doesn't represent an interface, call the specific
-				// function implementation of the current class to prevent virtual calls.
-				if(!entity.isInterface())
+				if(entity.getOverridden())
 				{
-					file << getSelfType(entity) << "::";
+					file << "static_cast <AG_" << overridden->getParent().getHierarchy("::AG_") << "*> (" <<
+							getObjectHandleName() << ")->";
+				}
+
+				else
+				{
+					file << "static_cast <AG_" << entity.getParent().getHierarchy("::AG_") << "*> (" <<
+							getObjectHandleName() << ")->" << getSelfType(entity) << "::";
 				}
 
 				file << entity.getName() << '(';
@@ -679,6 +713,7 @@ void GlueGenerator::generateClass(ClassEntity& entity)
 
 	entity.generateInterceptionContext(*this);
 	entity.generateNested(*this);
+	entity.generateConcreteType(*this);
 }
 
 void GlueGenerator::generateTypeReference(TypeReferenceEntity& entity)
@@ -719,27 +754,38 @@ void GlueGenerator::generateBridgeCall(FunctionEntity& target)
 		case FunctionEntity::Type::Constructor:
 		case FunctionEntity::Type::Destructor:
 		{
-			auto ctx = getClangContext(target);
-			assert(ctx);
-
-			// If the function is a private override of an interface, it cannot be called
-			// without a virtual function call. Call the virtual function for interface instead.
-			if(ctx->getOverloadContext()->isPrivateOverride())
+			auto overridden = target.getOverridden();
+			if(overridden)
 			{
-				auto& containing = ctx->getOverloadContext()->getOverriddenInterface()->getParent();
-				file << "AG_" << containing.getHierarchy("::AG_") << "::virtual_" <<
+				file << "// " << target.getHierarchy(".") << " overrides " << overridden->getHierarchy(".") << '\n';
+				file << "AG_" << overridden->getParent().getHierarchy("::AG_") << "::AG_virtual_" <<
 						target.getBridgeName(true) << '(';
 			}
 
-			// Call the corresponding function from the appropriate class.
-			// While some functions could directly be called in these bridge functions,
-			// stuff like protected functions cannot be invoked here directly. This
-			// is why we are invoking a method from a generated class
-			// impersonating the original class.
 			else
 			{
-				file << "AG_" << target.getParent().getHierarchy("::AG_") << "::" <<
-						target.getBridgeName(true) << '(';
+				auto ctx = getClangContext(target);
+				assert(ctx);
+
+				// If the function is a private override of an interface, it cannot be called
+				// without a virtual function call. Call the virtual function for interface instead.
+				if(ctx->getOverloadContext()->isPrivateOverride())
+				{
+					auto& containing = ctx->getOverloadContext()->getOverriddenInterface()->getParent();
+					file << "AG_" << containing.getHierarchy("::AG_") << "::AG_virtual_" <<
+							target.getBridgeName(true) << '(';
+				}
+
+				// Call the corresponding function from the appropriate class.
+				// While some functions could directly be called in these bridge functions,
+				// stuff like protected functions cannot be invoked here directly. This
+				// is why we are invoking a method from a generated class
+				// impersonating the original class.
+				else
+				{
+					file << "AG_" << target.getParent().getHierarchy("::AG_") << "::" <<
+							target.getBridgeName(true) << '(';
+				}
 			}
 
 			onlyParameterNames = true;

--- a/clang/GlueGenerator.cc
+++ b/clang/GlueGenerator.cc
@@ -328,14 +328,17 @@ public:
 			int toClose = 0;
 			file << "return ";
 
-			// If the type to return isn't trivially copyable, let's move it instead and
-			// return the object that way.
-			// TODO: What if the type isn't moveable?
-			auto ctx = getClangContext(entity);
-			if(ctx && !ctx->getTyperefContext()->isTypeTriviallyCopyable())
+			if(!entity.isReference())
 			{
-				file << "std::move(";
-				toClose++;
+				// If the type to return isn't trivially copyable, let's move it instead and
+				// return the object that way.
+				// TODO: What if the type isn't moveable?
+				auto ctx = getClangContext(entity);
+				if(ctx && !ctx->getTyperefContext()->isTypeTriviallyCopyable())
+				{
+					file << "std::move(";
+					toClose++;
+				}
 			}
 
 			toClose += generateForeignToGlue(entity);

--- a/clang/GlueGenerator.cc
+++ b/clang/GlueGenerator.cc
@@ -754,10 +754,12 @@ void GlueGenerator::generateBridgeCall(FunctionEntity& target)
 		case FunctionEntity::Type::Constructor:
 		case FunctionEntity::Type::Destructor:
 		{
+			// If the function represents an override within a concrete type, do a virtual
+			// call of the original overridable function. This is because a foreign language
+			// might not know the actual type that a concrete type represents.
 			auto overridden = target.getOverridden();
 			if(overridden)
 			{
-				file << "// " << target.getHierarchy(".") << " overrides " << overridden->getHierarchy(".") << '\n';
 				file << "AG_" << overridden->getParent().getHierarchy("::AG_") << "::AG_virtual_" <<
 						target.getBridgeName(true) << '(';
 			}

--- a/test/main.cc
+++ b/test/main.cc
@@ -24,11 +24,15 @@ int main(int argc, char** argv)
 	// If autoglue is given to clangBackend, this will resolve the namespace.
 	auto ns = clangBackend.getRoot().resolve("ag");
 
+	printf("Hierarchy done\n");
+
 	// If something was resolved, export it.
 	if(ns)
 	{
 		ns->useAll();
 	}
+
+	printf("Usages done\n");
 
 	clangBackend.getRoot().resolve("std.basic_string_viewCharacter_char_traitsCharacter.size")->use();
 	clangBackend.getRoot().resolve("std.basic_string_viewCharacter_char_traitsCharacter.data")->use();

--- a/test/main.cc
+++ b/test/main.cc
@@ -24,20 +24,14 @@ int main(int argc, char** argv)
 	// If autoglue is given to clangBackend, this will resolve the namespace.
 	auto ns = clangBackend.getRoot().resolve("ag");
 
-	printf("Hierarchy done\n");
-
 	// If something was resolved, export it.
 	if(ns)
 	{
 		ns->useAll();
 	}
 
-	printf("Usages done\n");
-
 	clangBackend.getRoot().resolve("std.basic_string_viewCharacter_char_traitsCharacter.size")->use();
 	clangBackend.getRoot().resolve("std.basic_string_viewCharacter_char_traitsCharacter.data")->use();
-
-	//clangBackend.getRoot().resolve("ag.Entity")->list();
 
 	// Export glue code for C++.
 	ag::clang::GlueGenerator glueGen(clangBackend);

--- a/test/main.cc
+++ b/test/main.cc
@@ -30,6 +30,11 @@ int main(int argc, char** argv)
 		ns->useAll();
 	}
 
+	clangBackend.getRoot().resolve("std.basic_string_viewCharacter_char_traitsCharacter.size")->use();
+	clangBackend.getRoot().resolve("std.basic_string_viewCharacter_char_traitsCharacter.data")->use();
+
+	//clangBackend.getRoot().resolve("ag.Entity")->list();
+
 	// Export glue code for C++.
 	ag::clang::GlueGenerator glueGen(clangBackend);
 	glueGen.generateBindings();

--- a/test/main.cc
+++ b/test/main.cc
@@ -30,9 +30,6 @@ int main(int argc, char** argv)
 		ns->useAll();
 	}
 
-	clangBackend.getRoot().resolve("std.basic_string_viewCharacter_char_traitsCharacter.size")->use();
-	clangBackend.getRoot().resolve("std.basic_string_viewCharacter_char_traitsCharacter.data")->use();
-
 	// Export glue code for C++.
 	ag::clang::GlueGenerator glueGen(clangBackend);
 	glueGen.generateBindings();


### PR DESCRIPTION
Instead of just exporting a concrete type for any given `ag::ClassEntity`, a concrete type is made whenever a class has an overridable function. The reason for doing so is to gain support for invoking non-interface virtual functions on objects received from the source language such as C++ and allowing foreign languages to override non-interface virtual functions.

Additionally classes can no longer be explicitly set as abstract because it is done by ClassEntity itself.
This makes it easier for backends as they no longer have to know whether any given class is abstract.