### PR TITLE
Work on making std::function generate correctly

### DIFF
--- a/autoglue/CallableTypeEntity.cc
+++ b/autoglue/CallableTypeEntity.cc
@@ -35,6 +35,10 @@ const char* CallableTypeEntity::getTypeString()
 
 void CallableTypeEntity::onGenerate(BindingGenerator& generator)
 {
+	// TODO: Since some languages might want to export some interface
+	// that can be used to utilize a callable type entity when such
+	// is used by the language bindings, something like
+	// generator.generateCallableType should be called here.
 }
 
 }

--- a/autoglue/CallableTypeEntity.cc
+++ b/autoglue/CallableTypeEntity.cc
@@ -1,0 +1,40 @@
+#include <autoglue/CallableTypeEntity.hh>
+#include <autoglue/TypeReferenceEntity.hh>
+
+#include <cassert>
+
+namespace ag
+{
+
+CallableTypeEntity::CallableTypeEntity(std::shared_ptr <TypeReferenceEntity>&& returnType)
+	: TypeEntity("", Type::Callable), returnType(std::move(returnType))
+{
+	assert(this->returnType);
+	assert(this->returnType->getReferredPtr());
+
+	fullName = "Callable_" + this->returnType->getReferred().getName();
+}
+
+void CallableTypeEntity::addParameter(std::shared_ptr <TypeReferenceEntity>&& param)
+{
+	assert(param);
+	fullName += "_" + param->getReferred().getName();
+
+	addChild(std::move(param));
+}
+
+const std::string& CallableTypeEntity::getName() const
+{
+	return fullName;
+}
+
+const char* CallableTypeEntity::getTypeString()
+{
+	return "Callable type";
+}
+
+void CallableTypeEntity::onGenerate(BindingGenerator& generator)
+{
+}
+
+}

--- a/autoglue/Entity.cc
+++ b/autoglue/Entity.cc
@@ -216,7 +216,7 @@ void Entity::onList(std::string_view indent)
 
 bool Entity::hasName(std::string_view str)
 {
-	return name == str;
+	return getName() == str;
 }
 
 void Entity::onInitialize()

--- a/autoglue/include/autoglue/CallableTypeEntity.hh
+++ b/autoglue/include/autoglue/CallableTypeEntity.hh
@@ -1,0 +1,28 @@
+#ifndef AUTOGLUE_CALLABLE_TYPE_ENTITY_HH
+#define AUTOGLUE_CALLABLE_TYPE_ENTITY_HH
+
+#include <autoglue/TypeEntity.hh>
+
+namespace ag
+{
+
+class CallableTypeEntity : public TypeEntity
+{
+public:
+	CallableTypeEntity(std::shared_ptr <TypeReferenceEntity>&& returnType);
+
+	void addParameter(std::shared_ptr <TypeReferenceEntity>&& param);
+	const std::string& getName() const override;
+
+	const char* getTypeString() override;
+
+private:
+	void onGenerate(BindingGenerator& generator) override;
+
+	std::string fullName;
+	std::shared_ptr <TypeReferenceEntity> returnType;
+};
+
+}
+
+#endif

--- a/autoglue/include/autoglue/TypeEntity.hh
+++ b/autoglue/include/autoglue/TypeEntity.hh
@@ -13,6 +13,7 @@ public:
 	enum class Type
 	{
 		Primitive,
+		Callable,
 		Alias,
 		Class,
 		Enum

--- a/clang/Backend.cc
+++ b/clang/Backend.cc
@@ -149,8 +149,6 @@ static std::shared_ptr <ag::TypeEntity> getPrimitive(clang::QualType type)
 	return nullptr;
 }
 
-bool logArgs = false;
-
 class NodeVisitor : public clang::RecursiveASTVisitor <NodeVisitor>
 {
 public:
@@ -192,12 +190,6 @@ private:
 	{
 		if(auto* templateDecl = clang::dyn_cast <clang::ClassTemplateSpecializationDecl> (named))
 		{
-			logArgs = name.find("function") != std::string::npos;
-			if(logArgs)
-			{
-				//printf("Logging args for '%s'\n", name.c_str());
-			}
-
 			// Append all of the template arguments after the name.
 			const auto& args = templateDecl->getTemplateArgs();
 			for(size_t i = 0; i < args.size(); i++)
@@ -244,8 +236,6 @@ private:
 				}
 			}
 		}
-
-		logArgs = false;
 	}
 
 	std::string getEntityName(const clang::NamedDecl* named)
@@ -332,11 +322,6 @@ private:
 
 	std::shared_ptr <ag::TypeEntity> resolveType(clang::QualType type)
 	{
-		//if(logArgs)
-		//{
-		//	printf("Resolving arg '%s'\n", type.getAsString().c_str());
-		//}
-
 		if(type->isFunctionType())
 		{
 			return resolveFunctionType(type);

--- a/clang/GlueGenerator.cc
+++ b/clang/GlueGenerator.cc
@@ -585,6 +585,7 @@ public:
 			}
 
 			case TypeEntity::Type::Primitive:
+			case TypeEntity::Type::Callable:
 			{
 				return false;
 			}
@@ -596,6 +597,8 @@ public:
 				return generateGlueToForeign(underlying);
 			}
 		}
+
+		return false;
 	}
 
 	int generateForeignToGlue(TypeReferenceEntity& entity)
@@ -664,6 +667,11 @@ public:
 				TypeReferenceEntity underlying(entity.getName(), entity.getAliasType().getUnderlying(true), entity.isReference());
 				underlying.initializeContext(entity.getContext());
 				return generateForeignToGlue(underlying);
+			}
+
+			case TypeEntity::Type::Callable:
+			{
+				// TODO: Something with function pointers?
 			}
 		}
 

--- a/csharp/generator/BindingGenerator.cc
+++ b/csharp/generator/BindingGenerator.cc
@@ -713,6 +713,11 @@ bool BindingGenerator::generateBridgeToCSharp(TypeReferenceEntity& entity)
 
 			break;
 		}
+
+		case TypeEntity::Type::Callable:
+		{
+			// TODO: Something here?
+		}
 	}
 
 	return false;
@@ -746,6 +751,7 @@ bool BindingGenerator::generateCSharpToBridge(TypeReferenceEntity& entity)
 		}
 
 		case TypeEntity::Type::Primitive:
+		case TypeEntity::Type::Callable:
 		{
 			break;
 		}

--- a/java/generator/BindingGenerator.cc
+++ b/java/generator/BindingGenerator.cc
@@ -545,6 +545,11 @@ void BindingGenerator::generateTyperefJNI(TypeReferenceEntity& entity)
 				jni << typeName << ' ' << entity.getName();
 				break;
 			}
+
+			case TypeEntity::Type::Callable:
+			{
+				// TODO: Something here?
+			}
 		}
 	}
 }
@@ -763,6 +768,7 @@ bool BindingGenerator::generateReturnStatement(TypeReferenceEntity& entity, Func
 			}
 
 			case TypeEntity::Type::Primitive:
+			case TypeEntity::Type::Callable:
 			{
 				file << "return ";
 				break;


### PR DESCRIPTION
The primary purpose of this PR is to make `std::function` generate correctly.

To make this happen, `ag::CallableTypeEntity` is added which can be used to represent a callable type, such as a C/C++ function type.

Additionally `ag::clang::TypeContext` now reports a more accurate name for any given type as it no longer depends on `appendTemplateArguments` but asks clang the exact type name.